### PR TITLE
Add preliminary JUnit tests

### DIFF
--- a/digest-enforcer-rules/pom.xml
+++ b/digest-enforcer-rules/pom.xml
@@ -58,6 +58,13 @@
       <version>${maven.version}</version>
     </dependency>
 
+    <!-- Test dependencies -->
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/digest-enforcer-rules/src/main/java/uk/co/froot/maven/enforcer/DigestRule.java
+++ b/digest-enforcer-rules/src/main/java/uk/co/froot/maven/enforcer/DigestRule.java
@@ -48,6 +48,11 @@ public class DigestRule implements EnforcerRule {
   private ArtifactResolver resolver = null;
   private Log log = null;
 
+  // Required for testing
+  protected void setUrns(String... urns) {
+    this.urns = urns;
+  }
+
   public String getCacheId() {
     return "id"; // This is not cacheable
   }

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/DigestRuleTest.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/DigestRuleTest.java
@@ -1,0 +1,186 @@
+package uk.co.froot.maven.enforcer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import uk.co.froot.maven.enforcer.testutil.ArtifactFactoryHelper;
+import uk.co.froot.maven.enforcer.testutil.ArtifactHelper;
+import uk.co.froot.maven.enforcer.testutil.ArtifactRepositoryHelper;
+import uk.co.froot.maven.enforcer.testutil.ArtifactResolverHelper;
+import uk.co.froot.maven.enforcer.testutil.ProjectHelper;
+
+public class DigestRuleTest {
+
+    private static final Object KEY_PROJECT = "${project}";
+    private static final Object KEY_LOCAL_REPOSITORY = "${localRepository}";
+    @SuppressWarnings("deprecation")
+    private static final Object KEY_ArtifactFactory = org.apache.maven.artifact.factory.ArtifactFactory.class;
+    private static final Object KEY_ArtifactResolver = ArtifactResolver.class;
+    private static final File dummyArtifactFile = new File("target/test/Dep.jar");
+    private static final String fileContent = "This is a dummy file";
+    private static final String fileContentSHA = "e2648e9f0e220678a5ca1d71be6c42b7296ee329";
+
+    @BeforeClass
+    public static void init() {
+        final File folder = dummyArtifactFile.getParentFile();
+        System.out.println(folder.getAbsolutePath());
+        folder.mkdirs();
+        final File dummyArtifactShaFile = new File(folder, dummyArtifactFile.getName() + ".sha1");
+        writeFile(dummyArtifactFile, fileContent.getBytes());
+        writeFile(dummyArtifactShaFile, fileContentSHA.getBytes());
+    }
+
+    private static void writeFile(final File file, final byte[] bytes) {
+        FileOutputStream fos = null;
+        try {
+            fos = new FileOutputStream(file);
+            fos.write(bytes);
+        } catch (final IOException e) {
+        	e.printStackTrace();
+            if (fos != null) {
+                try {
+                    fos.close();
+                } catch (final IOException e2) {
+                	e2.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private static Artifact dummyArtifact(final String name, final String version, final String scope) {
+        final Artifact artifact = new ArtifactHelper(name, version, scope);
+        artifact.setFile(dummyArtifactFile);
+        return artifact;
+    }
+
+    private static String urn(final Artifact artifact) {
+        return artifact.toString() + ":" + fileContentSHA;
+    }
+
+    private static Artifact DUMMY_ARTIFACT = dummyArtifact("test1", "1.2.0", "compile");
+    private static String DUMMY_URN = urn(DUMMY_ARTIFACT);
+    private static String DUMMY_URN_HASH = DUMMY_URN.substring(0, DUMMY_URN.length() - 1) + 'a';
+    private static String DUMMY_URN_SCOPE = DUMMY_URN.replace("compile", "runtime");
+
+    private static ProjectHelper dummyHelper() {
+        final ProjectHelper helper = new ProjectHelper();
+        helper.set(KEY_LOCAL_REPOSITORY, new ArtifactRepositoryHelper());
+        helper.set(KEY_ArtifactFactory, new ArtifactFactoryHelper(dummyArtifactFile));
+        helper.set(KEY_ArtifactResolver, new ArtifactResolverHelper());
+        return helper;
+    }
+
+    private static MavenProject dummyProject(final ProjectHelper helper) {
+        final MavenProject project = new MavenProject();
+        helper.set(KEY_PROJECT, project);
+        project.setPluginArtifacts(new HashSet<Artifact>());
+        project.getArtifacts();
+        return project;
+    }
+
+    @Test
+    public void testWithDependencyURN() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns(DUMMY_URN);
+
+        rule.execute(helper);
+    }
+
+    @Test(expected = EnforcerRuleException.class)
+    public void testWithoutDependencyURN() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns();
+
+        rule.execute(helper);
+    }
+
+    @Test(expected = EnforcerRuleException.class)
+    public void testWithDependencyURNHash() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns(DUMMY_URN_HASH);
+
+        rule.execute(helper);
+    }
+
+    @Test(expected = EnforcerRuleException.class)
+    public void testWithDependencyURNScope() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns(DUMMY_URN_SCOPE);
+
+        rule.execute(helper);
+    }
+
+    @Test
+    public void testWithPluginURN() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getPluginArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns(DUMMY_URN);
+
+        rule.execute(helper);
+    }
+
+    @Test(expected = EnforcerRuleException.class)
+    public void testWithoutPluginURN() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getPluginArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns();
+
+        rule.execute(helper);
+    }
+
+    @Test(expected = EnforcerRuleException.class)
+    public void testWithPluginURNHash() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getPluginArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns(DUMMY_URN_HASH);
+
+        rule.execute(helper);
+    }
+
+    @Test(expected = EnforcerRuleException.class)
+    public void testWithPluginURNScope() throws EnforcerRuleException {
+        final DigestRule rule = new DigestRule();
+        final ProjectHelper helper = dummyHelper();
+        final MavenProject project = dummyProject(helper);
+
+        project.getPluginArtifacts().add(DUMMY_ARTIFACT);
+        rule.setUrns(DUMMY_URN_SCOPE);
+
+        rule.execute(helper);
+    }
+
+}

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactFactoryHelper.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactFactoryHelper.java
@@ -1,0 +1,25 @@
+package uk.co.froot.maven.enforcer.testutil;
+
+import java.io.File;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.DefaultArtifactFactory;
+import org.apache.maven.artifact.versioning.VersionRange;
+
+public class ArtifactFactoryHelper extends DefaultArtifactFactory {
+
+    private final File file;
+
+    public ArtifactFactoryHelper(final File file) {
+        this.file = file;
+    }
+
+    @Override
+    public Artifact createDependencyArtifact(final String groupId, final String artifactId, final VersionRange versionRange,
+            final String type, final String classifier, final String scope) {
+        final Artifact artifact = new ArtifactHelper(artifactId, versionRange.toString(), scope);
+        artifact.setFile(this.file);
+        return artifact;
+    }
+
+}

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactHelper.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactHelper.java
@@ -1,0 +1,266 @@
+package uk.co.froot.maven.enforcer.testutil;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.metadata.ArtifactMetadata;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
+import org.apache.maven.artifact.versioning.VersionRange;
+
+@SuppressWarnings("deprecation")
+public class ArtifactHelper implements Artifact {
+
+    private final String name;
+    private final String version;
+    private final String scope;
+    private File file;
+
+    public ArtifactHelper(final String name, final String version, final String scope) {
+        this.name = name;
+        this.version = version;
+        this.scope = scope;
+    }
+
+    @Override
+    public int compareTo(final Artifact o) {
+        return getArtifactId().compareTo(o.getArtifactId());
+    }
+
+    @Override
+    public String getGroupId() {
+        return "test";
+    }
+
+    @Override
+    public String getArtifactId() {
+        return this.name;
+    }
+
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public void setVersion(final String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getScope() {
+        return this.scope;
+    }
+
+    @Override
+    public String getType() {
+        return "jar";
+    }
+
+    @Override
+    public String getClassifier() {
+        return null;
+    }
+
+    @Override
+    public boolean hasClassifier() {
+        return false;
+    }
+
+    @Override
+    public File getFile() {
+        return this.file;
+    }
+
+    @Override
+    public void setFile(final File destination) {
+        this.file = destination;
+    }
+
+    @Override
+    public String getBaseVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBaseVersion(final String baseVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDependencyConflictId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addMetadata(final ArtifactMetadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<ArtifactMetadata> getMetadataList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRepository(final ArtifactRepository remoteRepository) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactRepository getRepository() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateVersion(final String version, final ArtifactRepository localRepository) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDownloadUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDownloadUrl(final String downloadUrl) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactFilter getDependencyFilter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDependencyFilter(final ArtifactFilter artifactFilter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactHandler getArtifactHandler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getDependencyTrail() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDependencyTrail(final List<String> dependencyTrail) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setScope(final String scope) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VersionRange getVersionRange() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setVersionRange(final VersionRange newRange) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void selectVersion(final String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setGroupId(final String groupId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setArtifactId(final String artifactId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSnapshot() {
+        return false;
+    }
+
+    @Override
+    public void setResolved(final boolean resolved) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isResolved() {
+        return true;
+    }
+
+    @Override
+    public void setResolvedVersion(final String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setArtifactHandler(final ArtifactHandler handler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRelease() {
+        return true;
+    }
+
+    @Override
+    public void setRelease(final boolean release) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ArtifactVersion> getAvailableVersions() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAvailableVersions(final List<ArtifactVersion> versions) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public void setOptional(final boolean optional) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactVersion getSelectedVersion() throws OverConstrainedVersionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSelectedVersionKnown() throws OverConstrainedVersionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        // groupId:artifactId:version:type:classifier:scope
+        return getGroupId() + ":" + getArtifactId() + ":" + getVersion() + ":" + getType() + ":" + getClassifier() + ":" + getScope();
+    }
+
+}

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactRepositoryHelper.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactRepositoryHelper.java
@@ -1,0 +1,157 @@
+package uk.co.froot.maven.enforcer.testutil;
+
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.metadata.ArtifactMetadata;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.Authentication;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
+import org.apache.maven.repository.Proxy;
+
+//TODO: Replace with proper mock objects
+@SuppressWarnings("deprecation")
+public class ArtifactRepositoryHelper implements ArtifactRepository {
+
+    @Override
+    public String pathOf(Artifact artifact) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String pathOfRemoteRepositoryMetadata(ArtifactMetadata artifactMetadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String pathOfLocalRepositoryMetadata(ArtifactMetadata metadata, ArtifactRepository repository) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setUrl(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getBasedir() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocol() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setId(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactRepositoryPolicy getSnapshots() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSnapshotUpdatePolicy(ArtifactRepositoryPolicy policy) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactRepositoryPolicy getReleases() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReleaseUpdatePolicy(ArtifactRepositoryPolicy policy) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArtifactRepositoryLayout getLayout() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLayout(ArtifactRepositoryLayout layout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getKey() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUniqueVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isBlacklisted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBlacklisted(boolean blackListed) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Artifact find(Artifact artifact) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> findVersions(Artifact artifact) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isProjectAware() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAuthentication(Authentication authentication) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Authentication getAuthentication() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setProxy(Proxy proxy) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Proxy getProxy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ArtifactRepository> getMirroredRepositories() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMirroredRepositories(List<ArtifactRepository> mirroredRepositories) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactResolverHelper.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ArtifactResolverHelper.java
@@ -1,0 +1,14 @@
+package uk.co.froot.maven.enforcer.testutil;
+
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.DefaultArtifactResolver;
+
+public class ArtifactResolverHelper extends DefaultArtifactResolver {
+
+    @Override
+    public ArtifactResolutionResult resolve(final ArtifactResolutionRequest request) {
+        return null;
+    }
+
+}

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/LogHelper.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/LogHelper.java
@@ -1,0 +1,91 @@
+package uk.co.froot.maven.enforcer.testutil;
+
+import org.apache.maven.plugin.logging.Log;
+
+public class LogHelper implements Log {
+
+    @Override
+    public boolean isDebugEnabled() {
+        return true;
+    }
+
+    @Override
+    public void debug(final CharSequence content) {
+        System.out.println(content);
+    }
+
+    @Override
+    public void debug(final CharSequence content, final Throwable error) {
+        debug(content);
+        debug(error);
+    }
+
+    @Override
+    public void debug(final Throwable error) {
+        error.printStackTrace(System.out);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return true;
+    }
+
+    @Override
+    public void info(final CharSequence content) {
+        System.out.println(content);
+    }
+
+    @Override
+    public void info(final CharSequence content, final Throwable error) {
+        info(content);
+        info(error);
+    }
+
+    @Override
+    public void info(final Throwable error) {
+        error.printStackTrace(System.out);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return true;
+    }
+
+    @Override
+    public void warn(final CharSequence content) {
+        System.out.println(content);
+    }
+
+    @Override
+    public void warn(final CharSequence content, final Throwable error) {
+        warn(content);
+        warn(error);
+    }
+
+    @Override
+    public void warn(final Throwable error) {
+        error.printStackTrace(System.out);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public void error(final CharSequence content) {
+        System.err.println(content);
+    }
+
+    @Override
+    public void error(final CharSequence content, final Throwable error) {
+        error(content);
+        error(error);
+    }
+
+    @Override
+    public void error(final Throwable error) {
+        error.printStackTrace(System.err);
+    }
+
+}

--- a/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ProjectHelper.java
+++ b/digest-enforcer-rules/src/test/java/uk/co/froot/maven/enforcer/testutil/ProjectHelper.java
@@ -1,0 +1,77 @@
+package uk.co.froot.maven.enforcer.testutil;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+
+@SuppressWarnings("rawtypes")
+public class ProjectHelper implements EnforcerRuleHelper {
+
+    private final Log log = new LogHelper();
+    private final Map<Object, Object> data = new HashMap<Object, Object>();
+
+    public void set(final Object key, final Object value) {
+        this.data.put(key, value);
+    }
+
+    private Object get(final Object key) {
+        final Object value = this.data.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Key " + key + " not found!");
+        }
+        return value;
+    }
+
+    @Override
+    public Object evaluate(final String expression) throws ExpressionEvaluationException {
+        return get(expression);
+    }
+
+    @Override
+    public File alignToBaseDirectory(final File file) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Log getLog() {
+        return this.log;
+    }
+
+    @Override
+    public Object getComponent(final Class clazz) throws ComponentLookupException {
+        return get(clazz);
+    }
+
+    @Override
+    public Object getComponent(final String componentKey) throws ComponentLookupException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getComponent(final String role, final String roleHint) throws ComponentLookupException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map getComponentMap(final String role) throws ComponentLookupException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List getComponentList(final String role) throws ComponentLookupException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PlexusContainer getContainer() {
+        throw new UnsupportedOperationException();
+    }
+
+}


### PR DESCRIPTION
I added some preliminary JUnit tests. They should cover some of the points mentioned in: https://github.com/gary-rowe/BitcoinjEnforcerRules/issues/1#issuecomment-245021557

This is only a quick (and dirty) implementation of those tests. If you or somebody knows a way to improve them feel free to do so.

Currently two of those tests are failing:
- testWithoutDependencyURN
- testWithoutPluginURN

Because your plugin does not detect those issues.
